### PR TITLE
Management/Logistics Page

### DIFF
--- a/AdminClient/src/app/app.module.ts
+++ b/AdminClient/src/app/app.module.ts
@@ -28,6 +28,7 @@ import {SharedModule} from './shared/shared.module';
 import {UserEffects} from './user/store/user.effects';
 import {CustomersEffects} from './customers/store/customers.effects';
 import {ToolbarComponent} from './toolbar/toolbar.component';
+import { ManagementComponent } from './management/management.component';
 
 export const getToken = () => localStorage.getItem(environment.ACCESS_TOKEN);
 
@@ -35,7 +36,8 @@ export const getToken = () => localStorage.getItem(environment.ACCESS_TOKEN);
 	declarations: [
 		AppComponent,
 		DashboardComponent,
-		ToolbarComponent
+		ToolbarComponent,
+		ManagementComponent
 	],
 	bootstrap: [AppComponent],
 	imports: [

--- a/AdminClient/src/app/management/management.component.html
+++ b/AdminClient/src/app/management/management.component.html
@@ -1,0 +1,1 @@
+<p>management works!</p>

--- a/AdminClient/src/app/management/management.component.spec.ts
+++ b/AdminClient/src/app/management/management.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ManagementComponent } from './management.component';
+
+describe('ManagementComponent', () => {
+  let component: ManagementComponent;
+  let fixture: ComponentFixture<ManagementComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ ManagementComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ManagementComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/AdminClient/src/app/management/management.component.ts
+++ b/AdminClient/src/app/management/management.component.ts
@@ -1,0 +1,15 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-management',
+  templateUrl: './management.component.html',
+  styleUrls: ['./management.component.scss']
+})
+export class ManagementComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit(): void {
+  }
+
+}


### PR DESCRIPTION
Please give me feedback for the following implementation idea 

- Introducing a management page! (note: branch is still 'adminCustomersToRepresentative' but could be renamed to 'adminManagementPage')
- One for admin client, one page equivalent for rep client

**COMPONENT PLAN** (TO DO)

- Component should allow to assign/edit/delete customers to representative (Admin Client)
- Should allow representatives to edit details for each customer (Rep Client)
- Reps could do the following from the rep client... (Integration with Rep client is needed)
* Change the progress on a specific customer
* Make and save public notes (that are time stamped) regarding the customer (allows company management staff/other reps that are authorised by management to see this customer - to catch up on work for a customer)
* Show products that have been purchased most often from specific customers e.g. stone company (our customer) sells more white marble than blue marble to a contractor company working with stone (great for visualising)

(Admin Client will display all of the above calling the data from the logged in rep)

This is a suggestion to add more data for us to play with/show and visualise, perhaps could integrate this section with Grafana where possible. Let me know what you guys think!

Addresses #11 as one of the requirements